### PR TITLE
added missing include

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -6,6 +6,8 @@
 
 #include "core.h"
 #include "util.h"
+#include "main.h"
+#include "uint256.h"
 
 std::string COutPoint::ToString() const
 {


### PR DESCRIPTION
This will fix compiling error(chainactive.height() was not declare in the scope) . I forget to add these include last time
