### PR TITLE
A Fix to "getblock "hash""

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -231,7 +231,10 @@ uint256 CBlockHeader::GetHashX11() const
 {
     return HashX11(BEGIN(nVersion), END(nNonce));
 }
-
+uint256 CBlockHeader::GetHashX17(int nHeight ) const
+{
+   	return HashX17(BEGIN(nVersion), END(nNonce));
+}
 uint256 CBlock::BuildMerkleTree() const
 {
     vMerkleTree.clear();

--- a/src/core.h
+++ b/src/core.h
@@ -256,8 +256,9 @@ public:
         return (vin.empty() && vout.empty());
     }
 
-    uint256 GetHash() const;
-	uint256 GetHashX11() const;
+    uint256 GetHash(int nHeight = NULL) const;
+    uint256 GetHashX11(int nHeight = NULL) const;
+    uint256 GetHashX17(int nHeight = NULL) const;
     bool IsNewerThan(const CTransaction& old) const;
 
     // Return sum of txouts.


### PR DESCRIPTION
this function
if (fCheckPOW && !CheckProofOfWork(block.GetHash(), block.nBits))
        return state.DoS(50, error("CheckBlock() : proof of work failed"),
                         REJECT_INVALID, "high-hash"); 

may create problems ....we can try by reverting it back to original one as it was at the time of X11.

This function creat the block to go as orphan .....but running wallet again will force it to accept one orphan block. So, wallet will got crash .

It is better to configure testnet and test it.
