### PR TITLE
New feature allows to shrink debug file periodically

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -337,6 +337,7 @@ std::string HelpMessage(HelpMessageMode hmm)
         strUsage += "                         " + _("In this mode -genproclimit controls how many blocks are generated immediately.") + "\n";
     }
     strUsage += "  -shrinkdebugfile         " + _("Shrink debug.log file on client startup (default: 1 when no -debug)") + "\n";
+    strUsage += "  -shrinkdebuginterval=<n> " + _("Shrink debug.log file on each n hours (default: 0)") + "\n";
     strUsage += "  -testnet                 " + _("Use the test network") + "\n";
     strUsage += "  -promode=<n>             " + _("Activate all Masternode and Darksend related functionality (0-1, default: 0)") + "\n";
 	strUsage += "  -disable_DS_InstantX=<n> " + _("Disable all Masternode and Darksend related functionality in Core (0-1, default: 0)") + "\n";
@@ -684,6 +685,13 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     if (GetBoolArg("-shrinkdebugfile", !fDebug))
         ShrinkDebugFile();
+
+    int nShrinkDebugInterval = GetArg("-shrinkdebuginterval", 0);
+    if (0 < nShrinkDebugInterval && nShrinkDebugInterval < 100000) {
+        // Run a thread to shrink debug file periodically
+        threadGroup.create_thread(boost::bind(&ShrinkDebugFileInterval, nShrinkDebugInterval));
+    }
+
     LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     LogPrintf("Bitsend version %s (%s)\n", FormatFullVersion(), CLIENT_DATE);
     LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
@@ -784,7 +792,7 @@ if(nWalletBackups > 0)
                         }
                     }
                 }
-                
+
             }
        }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -337,7 +337,7 @@ std::string HelpMessage(HelpMessageMode hmm)
         strUsage += "                         " + _("In this mode -genproclimit controls how many blocks are generated immediately.") + "\n";
     }
     strUsage += "  -shrinkdebugfile         " + _("Shrink debug.log file on client startup (default: 1 when no -debug)") + "\n";
-    strUsage += "  -shrinkdebuginterval=<n> " + _("Shrink debug.log file on each n hours (default: 0)") + "\n";
+    strUsage += "  -shrinkdebuginterval=<n> " + _("Shrink debug.log file on each n hours (0-100000, default: 24)") + "\n";
     strUsage += "  -testnet                 " + _("Use the test network") + "\n";
     strUsage += "  -promode=<n>             " + _("Activate all Masternode and Darksend related functionality (0-1, default: 0)") + "\n";
 	strUsage += "  -disable_DS_InstantX=<n> " + _("Disable all Masternode and Darksend related functionality in Core (0-1, default: 0)") + "\n";
@@ -686,7 +686,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     if (GetBoolArg("-shrinkdebugfile", !fDebug))
         ShrinkDebugFile();
 
-    int nShrinkDebugInterval = GetArg("-shrinkdebuginterval", 0);
+    int nShrinkDebugInterval = GetArg("-shrinkdebuginterval", 24);
     if (0 < nShrinkDebugInterval && nShrinkDebugInterval < 100000) {
         // Run a thread to shrink debug file periodically
         threadGroup.create_thread(boost::bind(&ShrinkDebugFileInterval, nShrinkDebugInterval));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1295,6 +1295,13 @@ void ShrinkDebugFile()
         fclose(file);
 }
 
+void ShrinkDebugFileInterval(int interval) {
+    while (1) {
+        boost::this_thread::sleep( boost::posix_time::hours(interval) );
+        ShrinkDebugFile();
+    }
+}
+
 //
 // "Never go to sea with two chronometers; take one or three."
 // Our three time sources are:

--- a/src/util.h
+++ b/src/util.h
@@ -210,6 +210,7 @@ boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
 boost::filesystem::path GetTempPath();
 void ShrinkDebugFile();
+void ShrinkDebugFileInterval(int interval);
 int GetRandInt(int nMax);
 uint64_t GetRand(uint64_t nMax);
 uint256 GetRandHash();


### PR DESCRIPTION
This pull request introduces new feature that will allow to configure wallet to shrink debug file periodically.

The feature can be activated with `-shrinkdebuginterval=n` CLI parameter, where _n_ is an interval in hours.

Proper testing is required.