### PR TITLE
Update MasterNodeList "full"

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1025,14 +1025,14 @@ UniValue masternodelist(const JSONRPCRequest& request)
                                mn.Status() << " " <<
                                mn.protocolVersion << " " <<
                                address2.ToString() << " " <<
-                               mn.vin.prevout.hash.ToString() << " " <<
+                               addrStream.str() << " " <<
                                mn.lastTimeSeen << " " << setw(8) <<
                                (mn.lastTimeSeen - mn.sigTime);
                 std::string output = stringStream.str();
                 stringStream << " " << strAddr;
                 if(strFilter !="" && stringStream.str().find(strFilter) == string::npos &&
                         strAddr.find(strFilter) == string::npos) continue;
-                obj.push_back(Pair(addrStream.str(), output));
+                obj.push_back(Pair(mn.vin.prevout.hash.ToString(), output));
             } else if (strMode == "lastseen") {
                 if(strFilter !="" && strAddr.find(strFilter) == string::npos) continue;
                 obj.push_back(Pair(strAddr,       (int64_t)mn.lastTimeSeen));


### PR DESCRIPTION
Setting the Correct Identifier for a mn to set the vin over the ip. As bitsend support multi mn per ip. The output form json to a object or array its kills off these nodes on masternodes.pro list. This will fix this.