### PR TITLE
undef BSD if present due to conflict with osx param.h macro

### DIFF
--- a/src/qt/bitsendamountfield.cpp
+++ b/src/qt/bitsendamountfield.cpp
@@ -14,10 +14,6 @@
 #include <QKeyEvent>
 #include <QLineEdit>
 
-#ifdef BSD
-#undef BSD
-#endif
-
 /** QSpinBox that uses fixed-point numbers internally and uses our own
  * formatting/parsing functions.
  */
@@ -28,7 +24,7 @@ class AmountSpinBox: public QAbstractSpinBox
 public:
     explicit AmountSpinBox(QWidget *parent):
         QAbstractSpinBox(parent),
-        currentUnit(BitsendUnits::BSD),
+        currentUnit(BitsendUnits::BsD),
         singleStep(100000) // satoshis
     {
         setAlignment(Qt::AlignRight);
@@ -103,7 +99,7 @@ public:
 
             const QFontMetrics fm(fontMetrics());
             int h = lineEdit()->minimumSizeHint().height();
-            int w = fm.width(BitsendUnits::format(BitsendUnits::BSD, BitsendUnits::maxMoney(), false, BitsendUnits::separatorAlways));
+            int w = fm.width(BitsendUnits::format(BitsendUnits::BsD, BitsendUnits::maxMoney(), false, BitsendUnits::separatorAlways));
             w += 2; // cursor blinking space
 
             QStyleOptionSpinBox opt;

--- a/src/qt/bitsendamountfield.cpp
+++ b/src/qt/bitsendamountfield.cpp
@@ -14,6 +14,10 @@
 #include <QKeyEvent>
 #include <QLineEdit>
 
+#ifdef BSD
+#undef BSD
+#endif
+
 /** QSpinBox that uses fixed-point numbers internally and uses our own
  * formatting/parsing functions.
  */

--- a/src/qt/bitsendunits.cpp
+++ b/src/qt/bitsendunits.cpp
@@ -8,10 +8,6 @@
 
 #include <QStringList>
 
-#ifdef BSD
-#undef BSD
-#endif
-
 BitsendUnits::BitsendUnits(QObject *parent):
         QAbstractListModel(parent),
         unitlist(availableUnits())
@@ -21,7 +17,7 @@ BitsendUnits::BitsendUnits(QObject *parent):
 QList<BitsendUnits::Unit> BitsendUnits::availableUnits()
 {
     QList<BitsendUnits::Unit> unitlist;
-    unitlist.append(BSD);
+    unitlist.append(BsD);
     unitlist.append(mBSD);
     unitlist.append(uBSD);
     return unitlist;
@@ -31,7 +27,7 @@ bool BitsendUnits::valid(int unit)
 {
     switch(unit)
     {
-    case BSD:
+    case BsD:
     case mBSD:
     case uBSD:
         return true;
@@ -44,7 +40,7 @@ QString BitsendUnits::name(int unit)
 {
     switch(unit)
     {
-    case BSD: return QString("BSD");
+    case BsD: return QString("BSD");
     case mBSD: return QString("mBSD");
     case uBSD: return QString::fromUtf8("μBSD");
     default: return QString("???");
@@ -55,7 +51,7 @@ QString BitsendUnits::description(int unit)
 {
     switch(unit)
     {
-    case BSD: return QString("Bitsends");
+    case BsD: return QString("Bitsends");
     case mBSD: return QString("Milli-Bitsends (1 / 1" THIN_SP_UTF8 "000)");
     case uBSD: return QString("Micro-Bitsends (1 / 1" THIN_SP_UTF8 "000" THIN_SP_UTF8 "000)");
     default: return QString("???");
@@ -66,7 +62,7 @@ qint64 BitsendUnits::factor(int unit)
 {
     switch(unit)
     {
-    case BSD:  return 100000000;
+    case BsD:  return 100000000;
     case mBSD: return 100000;
     case uBSD: return 100;
     default:   return 100000000;
@@ -77,7 +73,7 @@ int BitsendUnits::decimals(int unit)
 {
     switch(unit)
     {
-    case BSD: return 8;
+    case BsD: return 8;
     case mBSD: return 5;
     case uBSD: return 2;
     default: return 0;

--- a/src/qt/bitsendunits.cpp
+++ b/src/qt/bitsendunits.cpp
@@ -8,6 +8,10 @@
 
 #include <QStringList>
 
+#ifdef BSD
+#undef BSD
+#endif
+
 BitsendUnits::BitsendUnits(QObject *parent):
         QAbstractListModel(parent),
         unitlist(availableUnits())

--- a/src/qt/bitsendunits.h
+++ b/src/qt/bitsendunits.h
@@ -41,6 +41,10 @@
 #define THIN_SP_UTF8 REAL_THIN_SP_UTF8
 #define THIN_SP_HTML HTML_HACK_SP
 
+#ifdef BSD
+#undef BSD
+#endif
+
 /** Bitsend unit definitions. Encapsulates parsing and formatting
    and serves as list model for drop-down selection boxes.
 */

--- a/src/qt/bitsendunits.h
+++ b/src/qt/bitsendunits.h
@@ -41,10 +41,6 @@
 #define THIN_SP_UTF8 REAL_THIN_SP_UTF8
 #define THIN_SP_HTML HTML_HACK_SP
 
-#ifdef BSD
-#undef BSD
-#endif
-
 /** Bitsend unit definitions. Encapsulates parsing and formatting
    and serves as list model for drop-down selection boxes.
 */
@@ -60,7 +56,7 @@ public:
      */
     enum Unit
     {
-        BSD,
+        BsD,
         mBSD,
         uBSD
     };

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -32,6 +32,10 @@
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 
+#ifdef BSD
+#undef BSD
+#endif
+
 QList<CAmount> CoinControlDialog::payAmounts;
 CCoinControl* CoinControlDialog::coinControl = new CCoinControl();
 bool CoinControlDialog::fSubtractFeeFromAmount = false;

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -32,10 +32,6 @@
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 
-#ifdef BSD
-#undef BSD
-#endif
-
 QList<CAmount> CoinControlDialog::payAmounts;
 CCoinControl* CoinControlDialog::coinControl = new CCoinControl();
 bool CoinControlDialog::fSubtractFeeFromAmount = false;
@@ -574,7 +570,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     }
 
     // actually update labels
-    int nDisplayUnit = BitsendUnits::BSD;
+    int nDisplayUnit = BitsendUnits::BsD;
     if (model && model->getOptionsModel())
         nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -81,6 +81,10 @@ extern double NSAppKitVersionNumber;
 #endif
 #endif
 
+#ifdef BSD
+#undef BSD
+#endif
+
 namespace GUIUtil {
 
 QString dateTimeStr(const QDateTime &date)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -81,10 +81,6 @@ extern double NSAppKitVersionNumber;
 #endif
 #endif
 
-#ifdef BSD
-#undef BSD
-#endif
-
 namespace GUIUtil {
 
 QString dateTimeStr(const QDateTime &date)
@@ -196,7 +192,7 @@ bool parseBitsendURI(const QUrl &uri, SendCoinsRecipient *out)
         {
             if(!i->second.isEmpty())
             {
-                if(!BitsendUnits::parse(BitsendUnits::BSD, i->second, &rv.amount))
+                if(!BitsendUnits::parse(BitsendUnits::BsD, i->second, &rv.amount))
                 {
                     return false;
                 }
@@ -235,7 +231,7 @@ QString formatBitsendURI(const SendCoinsRecipient &info)
 
     if (info.amount)
     {
-        ret += QString("?amount=%1").arg(BitsendUnits::format(BitsendUnits::BSD, info.amount, false, BitsendUnits::separatorNever));
+        ret += QString("?amount=%1").arg(BitsendUnits::format(BitsendUnits::BsD, info.amount, false, BitsendUnits::separatorNever));
         paramCount++;
     }
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -70,7 +70,7 @@ void OptionsModel::Init(bool resetSettings)
 
     // Display
     if (!settings.contains("nDisplayUnit"))
-        settings.setValue("nDisplayUnit", BitsendUnits::BSD);
+        settings.setValue("nDisplayUnit", BitsendUnits::BsD);
     nDisplayUnit = settings.value("nDisplayUnit").toInt();
 
     if (!settings.contains("strThirdPartyTxUrls"))

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -21,6 +21,10 @@
 #define DECORATION_SIZE 54
 #define NUM_ITEMS 5
 
+#ifdef BSD
+#undef BSD
+#endif
+
 class TxViewDelegate : public QAbstractItemDelegate
 {
     Q_OBJECT

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -21,16 +21,12 @@
 #define DECORATION_SIZE 54
 #define NUM_ITEMS 5
 
-#ifdef BSD
-#undef BSD
-#endif
-
 class TxViewDelegate : public QAbstractItemDelegate
 {
     Q_OBJECT
 public:
     TxViewDelegate(const PlatformStyle *_platformStyle, QObject *parent=nullptr):
-        QAbstractItemDelegate(parent), unit(BitsendUnits::BSD),
+        QAbstractItemDelegate(parent), unit(BitsendUnits::BsD),
         platformStyle(_platformStyle)
     {
 


### PR DESCRIPTION
RE: https://github.com/LIMXTEC/BitSend/issues/84

This PR fixes an issue with the QT code which causes the executable to fail to build on OSX.

In bitsendunits.h the enum Units value BSD conflicts with the OSX Dev SDK param.h file which has the macro 

`#define BSD 199506 /* System version (year & month). */`

 If we undef the BSD macro where the enum is used, the build succeeds.
  
  